### PR TITLE
Filtered properties without public get or set methods out from dropdowns

### DIFF
--- a/UnityWeld/Binding/Internal/PropertyFinder.cs
+++ b/UnityWeld/Binding/Internal/PropertyFinder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -37,8 +37,11 @@ namespace UnityWeld.Binding.Internal
                         .GetProperties(BindingFlags.Instance | BindingFlags.Public)
                         .Select(p => new BindableMember<PropertyInfo>(p, type));
                 })
-                .Where(prop => !hiddenTypes.Contains(prop.ViewModelType))
-                .Where(prop => !prop.Member.GetCustomAttributes(typeof(ObsoleteAttribute), true).Any());
+                .Where(prop => prop.Member.GetSetMethod(false) != null 
+                    && prop.Member.GetGetMethod(false) != null
+                    && !hiddenTypes.Contains(prop.ViewModelType)
+                    && !prop.Member.GetCustomAttributes(typeof(ObsoleteAttribute), true).Any()
+                );
         }
     }
 }


### PR DESCRIPTION
Properties that can't be set or we can't get the value of aren't useful to bind to. These will throw an error if we try to bind to them and create clutter in the dropdowns.